### PR TITLE
Startup command fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /
 USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "-k", "uvicorn.workers.UvicornWorker", "backend.main:app"]
+CMD ["fastapi", "run", "backend/main.py", "--port", "8000"]


### PR DESCRIPTION
Er zat een fout in de startup command.
Deze gebruikte gunicorn, terwijl dit ingebouwd zit in fastapi en deze dus anders aangeroepen moest worden.