### PR TITLE
Implemented Owasp dependency check

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -32,7 +32,7 @@ jobs:
         wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
         unzip dependency-check-9.2.0-release.zip
         mkdir -p dependency-reports
-        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report
+        ./dependency-check/bin/dependency-check.sh --data ~/.owasp/dependency-check/data --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report
 
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4
       with:
-        name: dependency-check-report
+        name: dependency-check-report-${{ matrix.python-version }}
         path: ./dependency-reports/dependency-check-report

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -5,9 +5,10 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 720
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -20,12 +20,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-    - name: Run OWASP Dependency-Check
+       - name: Run OWASP Dependency-Check
       run: |
         wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
         unzip dependency-check-9.2.0-release.zip
         mkdir -p dependency-reports
-        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report
+        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --apiKey ${{ secrets.NVD_API_KEY }}
 
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -21,11 +21,11 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run OWASP Dependency-Check
-  run: |
-    wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
-    unzip dependency-check-9.2.0-release.zip
-    mkdir -p dependency-reports
-    ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --nvdApiKey ${{ secrets.NVD_API_KEY }}
+      run: |
+        wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
+        unzip dependency-check-9.2.0-release.zip
+        mkdir -p dependency-reports
+        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --nvdApiKey ${{ secrets.NVD_API_KEY }}
 
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 720
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -21,6 +21,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
+    - name: Cache NVD data
+      uses: actions/cache@v3
+      with:
+        path: ~/.owasp/dependency-check/data
+        key: ${{ runner.os }}-nvd-data
+
     - name: Run OWASP Dependency-Check
       run: |
         wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -20,7 +20,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
 
-       - name: Run OWASP Dependency-Check
+    - name: Run OWASP Dependency-Check
       run: |
         wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
         unzip dependency-check-9.2.0-release.zip

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -25,7 +25,7 @@ jobs:
         wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
         unzip dependency-check-9.2.0-release.zip
         mkdir -p dependency-reports
-        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --nvdApiKey ${{ secrets.NVD_API_KEY }}
+        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report
 
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,34 @@
+name: Dependency check
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run OWASP Dependency-Check
+      run: |
+        wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
+        unzip dependency-check-9.2.0-release.zip
+        mkdir -p dependency-reports
+        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report
+
+    - name: Upload dependency-check report
+      uses: actions/upload-artifact@v4
+      with:
+        name: dependency-check-report
+        path: ./dependency-reports/dependency-check-report

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,6 +1,9 @@
 name: Dependency check
 
-on: push
+# every sunday at 12 GMT+2
+on:
+  schedule:
+    - cron: '0 10 * * 0'
 
 jobs:
   build:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -21,11 +21,11 @@ jobs:
         pip install -r requirements.txt
 
     - name: Run OWASP Dependency-Check
-      run: |
-        wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
-        unzip dependency-check-9.2.0-release.zip
-        mkdir -p dependency-reports
-        ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --apiKey ${{ secrets.NVD_API_KEY }}
+  run: |
+    wget https://github.com/jeremylong/DependencyCheck/releases/download/v9.2.0/dependency-check-9.2.0-release.zip
+    unzip dependency-check-9.2.0-release.zip
+    mkdir -p dependency-reports
+    ./dependency-check/bin/dependency-check.sh --project "FastAPI Backend" --scan . --out ./dependency-reports/dependency-check-report --nvdApiKey ${{ secrets.NVD_API_KEY }}
 
     - name: Upload dependency-check report
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Used caching instead of the API key. Should we decide to use the key than we have to make a new issue with a new pr. 

For now the report gets made every time a push is made(this seems overkill), should i change this to when it gets merged into main?

dont merge the code. simply approve or disapprove my pr.