### PR TITLE
115 zap pipeline aanpassen wanneer het afgaat

### DIFF
--- a/.github/workflows/ZAP-security-pipeline-team1.yml
+++ b/.github/workflows/ZAP-security-pipeline-team1.yml
@@ -2,7 +2,7 @@ name: ZAP Scan Workflow
 
 on:
   schedule:
-    - cron: '30 14 * * *'
+    - cron: '0 12 * * 0'
 
 jobs:
   zap_scan_job:
@@ -11,6 +11,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with: { ref: main }
 
       - name: Log in to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/ZAP-security-pipeline-team1.yml
+++ b/.github/workflows/ZAP-security-pipeline-team1.yml
@@ -2,7 +2,7 @@ name: ZAP Scan Workflow
 
 on:
   schedule:
-    - cron: '20 14 * * *'
+    - cron: '30 14 * * *'
 
 jobs:
   zap_scan_job:

--- a/.github/workflows/ZAP-security-pipeline-team1.yml
+++ b/.github/workflows/ZAP-security-pipeline-team1.yml
@@ -1,9 +1,8 @@
 name: ZAP Scan Workflow
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '20 14 * * *'
 
 jobs:
   zap_scan_job:


### PR DESCRIPTION
ZAP reports only get created on Sunday 12:00 instead of on push. (suggestion of rob)
Tested the schedule on a seperate repo and it worked when set on "every 5 minutes" and also tested it on specific times.